### PR TITLE
change default dtstart to midnight and annual/bymonth recurrence to DAILY

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -236,6 +236,13 @@ class Rule(object):
         elif dtend:
             until = dtend
 
+        # Change yearly frequency to daily since recurrence is bymonth
+        # and the date (datetime.now()) is arbitrary and not transparent
+        # to the user.  A single event per month can be specified by 
+        # selecting a day of the month.
+        if self.freq == YEARLY and not kwargs.get('byweekday'):
+            self.freq = DAILY
+
         return dateutil.rrule.rrule(
             self.freq, dtstart, self.interval, self.wkst, self.count, until,
             cache=cache, **kwargs)

--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -259,7 +259,9 @@ class Recurrence(object):
         `dtstart` : datetime.datetime
             Optionally specify the first occurrence. This defaults to
             `datetime.datetime.now()` when the occurrence set is
-            generated.
+            generated. NOTE: Time is set to (0, 0) midnight to assist
+            in testing a recurrence for a particular date.  E.g.
+            `mydatetime_atmidnight in reccurrence == True | False`.
 
         `dtend` : datetime.datetime
             Optionally specify the last occurrence.
@@ -296,7 +298,10 @@ class Recurrence(object):
         """
         self._cache = {}
 
-        self.dtstart = dtstart
+        if dtstart:
+            self.dtstart = dtstart
+        else:
+            self.dtstart = datetime.datetime.combine(datetime.datetime.now(), datetime.time(0, 0))
         self.dtend = dtend
 
         self.rrules = list(rrules)


### PR DESCRIPTION
Not sure what you think of these changes.

The first commit makes it easier to test rulesets for a particular date by specifying the default time as (0,0) (instead of whatever now() was when the rule was created).

The second commit makes it possible to test whether a datetime exists within an annual recurrence when only the month (but not a specific day of the month) is selected.  I think this is more transparent to the user, since otherwise the particular date of the recurrence on a given month is hidden.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/django-recurrence/django-recurrence/3)

<!-- Reviewable:end -->
