### PR TITLE
Can't save None into a RecurrenceField

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -845,6 +845,9 @@ def serialize(rule_or_recurrence):
 
         return u';'.join(u'%s=%s' % (i[0], u','.join(i[1])) for i in values)
 
+    if rule_or_recurrence is None:
+        return None
+
     try:
         validate(rule_or_recurrence)
     except exceptions.ValidationError, error:

--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -33,6 +33,11 @@ class RecurrenceField(fields.Field):
         return recurrence.deserialize(value)
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
+        if value is None and self.null == False:
+            raise ValueError(
+                'Cannot assign None: "%s.%s" does not allow null values.' % (
+                self.model._meta.object_name, self.name))
+
         if isinstance(value, basestring):
             value = recurrence.deserialize(value)
         return recurrence.serialize(value)

--- a/recurrence/tests.py
+++ b/recurrence/tests.py
@@ -1,0 +1,26 @@
+from django.db import models
+from recurrence.fields import RecurrenceField
+import unittest
+
+
+class EventWithNoNulls(models.Model):
+    recurs = RecurrenceField(null=False)
+
+
+class EventWithNulls(models.Model):
+    recurs = RecurrenceField(null=True)
+
+
+class RecurrenceTestCase(unittest.TestCase):
+    def test_recurs_can_be_explicitly_none_if_none_is_allowed(self):
+        # Check we can save None correctly
+        event = EventWithNulls.objects.create(recurs=None)
+        self.assertEqual(event.recurs, None)
+
+        # Check we can deserialize None correctly
+        reloaded = EventWithNulls.objects.get(pk=event.pk)
+        self.assertEqual(reloaded.recurs, None)
+
+    def test_recurs_cannot_be_explicitly_none_if_none_is_disallowed(self):
+        with self.assertRaises(ValueError):
+            EventWithNoNulls.objects.create(recurs=None)


### PR DESCRIPTION
This change also adds the first of hopefully many more test
cases for django-recurrence.

Previously, if you had a model with a RecurrenceField like
this:

```
recurs = RecurrenceField(null=True)
```

You'd get a SerializationError raised when you did this:

```
MyModel.create(recurs=None)
```

With these changes, this can be saved as expected.

This change also fixes the next problem - saving None to
fields with null=False. With the first change, we got an
IntegrityError, since we now allow None values, but didn't
check for them before trying to save.

Note that none of this affects what happens if you're using
the recurrence widget (for example, if you save a value
through the admin) without modifying the default values.
There, you get a defaulted Recurrence object, not None.
