### PR TITLE
Don't break Django-1.7 migrations

### DIFF
--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -33,11 +33,6 @@ class RecurrenceField(fields.Field):
         return recurrence.deserialize(value)
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
-        if value is None and self.null == False:
-            raise ValueError(
-                'Cannot assign None: "%s.%s" does not allow null values.' % (
-                self.model._meta.object_name, self.name))
-
         if isinstance(value, basestring):
             value = recurrence.deserialize(value)
         return recurrence.serialize(value)


### PR DESCRIPTION
This reverts part of a201e23. An IntegrityError is exactly the right exception
that should be raised when trying to save None into a field with null=False.

Django-1.7 migrations ask for the db_prep_value for None and don't handle that
exception there.
