### PR TITLE
bug when current month has less than 31 days in monthly recurring

### DIFF
--- a/recurrence/static/recurrence/js/recurrence.js
+++ b/recurrence/static/recurrence/js/recurrence.js
@@ -146,6 +146,7 @@ recurrence.Rule.prototype = {
                 var items = recurrence.array.foreach(
                     this.bymonthday, function(day, i) {
                         var dt = new Date();
+                        dt.setMonth(0);
                         dt.setDate(day);
                         return recurrence.date.format(dt, '%j%S');
                 });


### PR DESCRIPTION
In such case, selecting the 31st cause the 1st to be shown in the
text.
