### PR TITLE
Fixed a minor documentation error for the course.recurrences.after code ...

### DIFF
--- a/docs/usage/recurrence_field.rst
+++ b/docs/usage/recurrence_field.rst
@@ -170,7 +170,7 @@ don't want that behaviour, you'll probably want to specify
    # Get the first course on or after 1st January 2010
    course.recurrences.after(
        datetime(2010, 1, 1, 0, 0, 0),
-       inc=True
+       inc=True,
        dtstart=datetime(2010, 1, 1, 0, 0, 0),
    )
 


### PR DESCRIPTION
Was using this and came across a missing , for the example in [course.recurrences.after](https://django-recurrence.readthedocs.org/en/latest/usage/recurrence_field.html#counting-occurrences).