### PR TITLE
Serializing Rule.wkst fails do to lookup via Weekday object instead of index value

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -842,7 +842,7 @@ def serialize(rule_or_recurrence):
         if rule.interval != 1:
             values.append((u'INTERVAL', [str(int(rule.interval))]))
         if rule.wkst:
-            values.append((u'WKST', [Rule.weekdays[rule.wkst]]))
+            values.append((u'WKST', [Rule.weekdays[rule.wkst.weekday]]))
 
         if rule.count is not None:
             values.append((u'COUNT', [str(rule.count)]))


### PR DESCRIPTION
If an rule included a `WKST`, serializing it would fail with the following exception, because the `Rule.wkst` attribute was used to look up the string representation instead of the weekday's index.

    TypeError: tuple indices must be integers, not Weekday