### PR TITLE
Include README.md in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.md
 include LICENSE
 include MANIFEST.in
 include pytest.ini


### PR DESCRIPTION
It's nice to have the README.md inside the source tarball so I can ship it as sort of a short documentation in the binary Debian packages for those who do not install the full documentation package.