### PR TITLE
sometimes rule.wkst is a weekday instance and not a number

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -842,7 +842,7 @@ def serialize(rule_or_recurrence):
         if rule.interval != 1:
             values.append((u'INTERVAL', [str(int(rule.interval))]))
         if rule.wkst:
-            values.append((u'WKST', [Rule.weekdays[rule.wkst]]))
+            values.append((u'WKST', [Rule.weekdays[getattr(rule.wkst, 'number', rule.wkst)]]))
 
         if rule.count is not None:
             values.append((u'COUNT', [str(rule.count)]))


### PR DESCRIPTION
I ran into a the situation where rule.wkst is sometimes already a weekday instance.

This change should allow the code to work whether it's a number or an instance.