### PR TITLE
Use server timezone in admin 

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -552,8 +552,8 @@ class Recurrence(object):
         for exrule in self.exrules:
             rruleset.exrule(exrule.to_dateutil_rrule(dtstart, dtend, cache))
 
-        if dtstart is not None:
-            rruleset.rdate(dtstart)
+        # if dtstart is not None:
+        #     rruleset.rdate(dtstart)
         for rdate in self.rdates:
             rdate = normalize_offset_awareness(rdate, dtstart)
             if dtend is not None and rdate < dtend:

--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -234,6 +234,13 @@ recurrence.widget.Calendar.prototype = {
     },
 
     set_date: function(year, month, day) {
+        // always reset time part
+        if (this.date){
+            this.date.setHours(0);
+            this.date.setMinutes(0);
+            this.date.setSeconds(0);
+            this.date._timezone = 'server';
+        }
         if (year != this.date.getFullYear() ||
             month != this.date.getMonth() ||
             day != this.date.getDate()) {
@@ -301,10 +308,13 @@ recurrence.widget.DateSelector.prototype = {
     init_dom: function() {
         var dateselector = this;
 
-        if (this.date)
+        if (this.date){
+            recurrence.convertToServerDate(this.date);
             var date_value = recurrence.date.format(this.date, '%Y-%m-%d');
-        else
+        }
+        else{
             var date_value = '';
+        }
         var date_field = recurrence.widget.e(
             'input', {
                 'class': 'date-field', 'size': 10,
@@ -351,6 +361,7 @@ recurrence.widget.DateSelector.prototype = {
         };
 
         if (!this.calendar) {
+            recurrence.convertToServerDate(this.date);
             this.calendar = new recurrence.widget.Calendar(
                 new Date((this.date || recurrence.widget.date_today()).valueOf()), {
                     'onchange': function() {
@@ -398,6 +409,13 @@ recurrence.widget.DateSelector.prototype = {
                 this.elements.date_field.value = '';
             }
         } else {
+            if(this.date){
+                this.date.setHours(0);
+                this.date.setMinutes(0);
+                this.date.setSeconds(0);
+                this.date._timezone= 'server';
+            }
+
             if (!this.date ||
                 (year != this.date.getFullYear() ||
                  month != this.date.getMonth() ||
@@ -1607,6 +1625,7 @@ recurrence.widget.DateForm.prototype = {
     },
 
     get_display_text: function() {
+        recurrence.convertToServerDate(this.date)
         var text = recurrence.date.format(this.date, pgettext('date', '%l, %F %j, %Y'));
         if (this.mode == recurrence.widget.EXCLUSION)
             text = recurrence.display.mode.exclusion + ' ' + text;


### PR DESCRIPTION
We are using django-recurrence in our project and noticed the time is using user's timezone, instead of server's timezone. When an admin is not in the same timezone as server setting, the time saved will be a few hours away from what we expected. Our site is UTC+1. 
Say we exclude date '2016-08-10' in admin form. If an admin is in UTC+1, the saved value would be 
20160809T230000Z. This would work correctly when we do a between(start, end, dtstart). 
However, if an admin is in UTC+8 timezone, entering the same '2016-08-10', the saved value would be 
20160809T160000Z. A between search would return unexpected results. 

issue is similar to #70 and #55 

I've modified it to always use server timezone in admin javascript. 

We also need a commit from @douwevandermeij. 
which automatically adding a rdate when dtstart is present. We cannot figure out the reason for that behavior. 
