### PR TITLE
use current timezone for localization

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -15,7 +15,6 @@ import calendar
 
 import pytz
 import dateutil.rrule
-from django.conf import settings
 from django.utils import dateformat, timezone
 from django.utils.translation import ugettext as _, pgettext as _p
 from django.utils.six import string_types


### PR DESCRIPTION
currently the local timezone is set using the default timezone setting,
however if a different timezone has been activated for the current user
then it would be optimal to convert the date to that timezone.  if no
timezone is currently set, then it will fall back to the default
`settings.TIME_ZONE` value