### PR TITLE
Update setup.py to include the migrations package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
 
     packages=(
         'recurrence',
+        'recurrence.migrations'
     ),
     package_dir={
         'recurrence': 'recurrence'


### PR DESCRIPTION
If you install django-recurrence the regular way (without the -e option), Django cannot find its migrations package, because it does not get installed. The setup.py file misses this entry in the ``packages`` directive.