### PR TITLE
Flexible handling of dtstart incl. documentation

### DIFF
--- a/docs/usage/recurrence_field.rst
+++ b/docs/usage/recurrence_field.rst
@@ -76,6 +76,42 @@ The effective starting date for any recurrence pattern is essentially
 the later of the first argument and ``dtstart``. To minimize
 confusion, you probably want to set them both to the same value.
 
+.. warning::
+
+   Note that per default ``dtstart`` will be the first occurence in
+   your list if specified, according to RFC 2445. This practice
+   deviates from how ``dateutil.rrule`` handles ``dtstart`` and can
+   therefore lead to confusion. Read on for how you can control this
+   behavior for your own recurrence patterns.
+
+To switch off the automatic inclusion of ``dtstart`` into the
+occurence list, set ``dtstart_inc=False`` as an argument for the
+``RecurrenceField`` whose behavior you want to change:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    class Course(models.Model):
+        title = models.CharField(max_length=200)
+        recurrences = RecurrenceField(dtstart_inc=False)
+
+With this change any ``dtstart`` value will only be an occurence if
+it matches the pattern specified in ``recurrences``. This also works
+for instantiating ``Recurrence`` objects directly:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    pattern = recurrence.Recurrence(
+       rrules=[recurrence.Rule(recurrence.WEEKLY, byday=recurrence.MONDAY)],
+       dtstart_inc=False).between(
+          datetime(2010, 1, 1, 0, 0, 0),
+          datetime(2014, 12, 31, 0, 0, 0),
+          dtstart=datetime(2010, 1, 1, 0, 0, 0),
+          inc=True
+       )
+    )
+
 .. _occurrences:
 
 Getting all occurrences

--- a/docs/usage/recurrence_field.rst
+++ b/docs/usage/recurrence_field.rst
@@ -85,7 +85,7 @@ confusion, you probably want to set them both to the same value.
    behavior for your own recurrence patterns.
 
 To switch off the automatic inclusion of ``dtstart`` into the
-occurence list, set ``dtstart_inc=False`` as an argument for the
+occurence list, set ``include_dtstart=False`` as an argument for the
 ``RecurrenceField`` whose behavior you want to change:
 
 .. code-block:: python
@@ -93,7 +93,7 @@ occurence list, set ``dtstart_inc=False`` as an argument for the
 
     class Course(models.Model):
         title = models.CharField(max_length=200)
-        recurrences = RecurrenceField(dtstart_inc=False)
+        recurrences = RecurrenceField(include_dtstart=False)
 
 With this change any ``dtstart`` value will only be an occurence if
 it matches the pattern specified in ``recurrences``. This also works
@@ -104,7 +104,7 @@ for instantiating ``Recurrence`` objects directly:
 
     pattern = recurrence.Recurrence(
        rrules=[recurrence.Rule(recurrence.WEEKLY, byday=recurrence.MONDAY)],
-       dtstart_inc=False).between(
+       include_dtstart=False).between(
           datetime(2010, 1, 1, 0, 0, 0),
           datetime(2014, 12, 31, 0, 0, 0),
           dtstart=datetime(2010, 1, 1, 0, 0, 0),

--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -932,7 +932,7 @@ def serialize(rule_or_recurrence):
     return u'\n'.join(u'%s:%s' % i for i in items)
 
 
-def deserialize(text):
+def deserialize(text, dtstart_inc=True):
     """
     Deserialize a rfc2445 formatted string.
 
@@ -1083,7 +1083,7 @@ def deserialize(text):
         elif label == u'EXDATE':
             exdates.append(deserialize_dt(params))
 
-    return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates)
+    return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates, dtstart_inc)
 
 
 def rule_to_text(rule, short=False):

--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -15,7 +15,6 @@ import calendar
 
 import pytz
 import dateutil.rrule
-from django.conf import settings
 from django.utils import dateformat, timezone
 from django.utils.translation import ugettext as _, pgettext as _p
 from django.utils.six import string_types
@@ -27,10 +26,6 @@ YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY, SECONDLY = range(7)
 
 (JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST,
  SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER) = range(1, 13)
-
-DTSTART_INCLUDE = settings.RECURRENCE_DTSTART_INCLUDE if hasattr(
-    settings, 'RECURRENCE_DTSTART_INCLUDE') and isinstance(
-    settings.RECURRENCE_DTSTART_INCLUDE, bool) else True
 
 
 def localtz():
@@ -298,11 +293,11 @@ class Recurrence(object):
             both the starting point for recurrences and the first
             recurrence in the set (according to the rfc2445 spec).
             With `dtstart_inc == False` `dtstart` is only the rule's
-            starting point like in python's rrule util.
+            starting point like in python's `dateutil.rrule`.
     """
     def __init__(
         self, dtstart=None, dtend=None, rrules=(), exrules=(),
-            rdates=(), exdates=(), dtstart_inc=DTSTART_INCLUDE
+            rdates=(), exdates=(), dtstart_inc=True
     ):
         """
         Create a new recurrence.

--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -287,17 +287,17 @@ class Recurrence(object):
             not be generated, even if some inclusive `Rule` or
             `datetime.datetime` instances matches them.
 
-        `dtstart_inc` : bool
+        `include_dtstart` : bool
             Defines if `dtstart` is included in the recurrence set as
-            the first occurrence. With `dtstart_inc == True` it is
+            the first occurrence. With `include_dtstart == True` it is
             both the starting point for recurrences and the first
             recurrence in the set (according to the rfc2445 spec).
-            With `dtstart_inc == False` `dtstart` is only the rule's
+            With `include_dtstart == False` `dtstart` is only the rule's
             starting point like in python's `dateutil.rrule`.
     """
     def __init__(
         self, dtstart=None, dtend=None, rrules=(), exrules=(),
-            rdates=(), exdates=(), dtstart_inc=True
+            rdates=(), exdates=(), include_dtstart=True
     ):
         """
         Create a new recurrence.
@@ -314,7 +314,7 @@ class Recurrence(object):
         self.exrules = list(exrules)
         self.rdates = list(rdates)
         self.exdates = list(exdates)
-        self.dtstart_inc = dtstart_inc
+        self.include_dtstart = include_dtstart
 
     def __iter__(self):
         return self.occurrences()
@@ -544,7 +544,7 @@ class Recurrence(object):
 
         dtstart = dtstart or self.dtstart
         dtend = dtend or self.dtend
-        dtstart_inc = self.dtstart_inc
+        include_dtstart = self.include_dtstart
 
         if dtend:
             dtend = normalize_offset_awareness(dtend or self.dtend, dtstart)
@@ -563,7 +563,7 @@ class Recurrence(object):
         for exrule in self.exrules:
             rruleset.exrule(exrule.to_dateutil_rrule(dtstart, dtend, cache))
 
-        if dtstart_inc and dtstart is not None:
+        if include_dtstart and dtstart is not None:
             rruleset.rdate(dtstart)
         for rdate in self.rdates:
             rdate = normalize_offset_awareness(rdate, dtstart)
@@ -932,7 +932,7 @@ def serialize(rule_or_recurrence):
     return u'\n'.join(u'%s:%s' % i for i in items)
 
 
-def deserialize(text, dtstart_inc=True):
+def deserialize(text, include_dtstart=True):
     """
     Deserialize a rfc2445 formatted string.
 
@@ -1083,7 +1083,7 @@ def deserialize(text, dtstart_inc=True):
         elif label == u'EXDATE':
             exdates.append(deserialize_dt(params))
 
-    return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates, dtstart_inc)
+    return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates, include_dtstart)
 
 
 def rule_to_text(rule, short=False):

--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -18,6 +18,10 @@ except ImportError:
 class RecurrenceField(fields.Field):
     """Field that stores a `recurrence.base.Recurrence` to the database."""
 
+    def __init__(self, dtstart_inc=True, **kwargs):
+        self.dtstart_inc = dtstart_inc
+        super(RecurrenceField, self).__init__(**kwargs)
+
     def get_internal_type(self):
         return 'TextField'
 
@@ -25,7 +29,7 @@ class RecurrenceField(fields.Field):
         if value is None or isinstance(value, recurrence.Recurrence):
             return value
         value = super(RecurrenceField, self).to_python(value) or u''
-        return recurrence.deserialize(value)
+        return recurrence.deserialize(value, self.dtstart_inc)
 
     def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)

--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -18,8 +18,8 @@ except ImportError:
 class RecurrenceField(fields.Field):
     """Field that stores a `recurrence.base.Recurrence` to the database."""
 
-    def __init__(self, dtstart_inc=True, **kwargs):
-        self.dtstart_inc = dtstart_inc
+    def __init__(self, include_dtstart=True, **kwargs):
+        self.include_dtstart = include_dtstart
         super(RecurrenceField, self).__init__(**kwargs)
 
     def get_internal_type(self):
@@ -29,7 +29,7 @@ class RecurrenceField(fields.Field):
         if value is None or isinstance(value, recurrence.Recurrence):
             return value
         value = super(RecurrenceField, self).to_python(value) or u''
-        return recurrence.deserialize(value, self.dtstart_inc)
+        return recurrence.deserialize(value, self.include_dtstart)
 
     def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+
+import pytest
 from django import forms
+
+import recurrence
 from recurrence import Recurrence, Rule
 from recurrence.forms import RecurrenceField
-import pytest
-import recurrence
 
 
 def test_clean_normal_value():
@@ -157,3 +159,65 @@ def test_check_allowable_frequencies():
     with pytest.raises(forms.ValidationError) as e:
         field.clean(value)
     assert e.value.messages[0] == "Invalid frequency."
+
+
+def test_dtstart_inc_from_field():
+    rule = Rule(
+        recurrence.WEEKLY,
+        byday=recurrence.MONDAY
+    )
+
+    limits = Recurrence(
+        rrules=[rule]
+    )
+
+    value = recurrence.serialize(limits)
+
+    model_field = recurrence.fields.RecurrenceField()  # Test with dtstart_inc=True (default)
+    rec_obj = model_field.to_python(value)
+    assert rec_obj == limits
+    # 2nd of August (dtstart) is expected but only for inc=True
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True,
+                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 2, 0, 0),
+                                                                   datetime(2015, 8, 3, 0, 0),
+                                                                   datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False,
+                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
+                                                                   datetime(2015, 8, 10, 0, 0)]
+
+    model_field = recurrence.fields.RecurrenceField(dtstart_inc=False)  # Test with dtstart_inc=False
+    rec_obj = model_field.to_python(value)
+    assert rec_obj == limits
+    # 2nd of August (dtstart) is not expected regardless of inc
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True,
+                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
+                                                                   datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False,
+                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
+                                                                   datetime(2015, 8, 10, 0, 0)]
+
+
+def test_dtstart_inc_from_object():
+    rule = Rule(
+        recurrence.WEEKLY,
+        byday=recurrence.MONDAY
+    )
+
+    limits = Recurrence(  # dtstart_inc=True (default)
+        rrules=[rule]
+    )
+
+    assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 2, 0, 0), datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+    assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+
+    limits = Recurrence(  # dtstart_inc=False (dtstart is expected to not be included)
+        dtstart_inc=False,
+        rrules=[rule]
+    )
+
+    assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+    assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -177,24 +177,19 @@ def test_dtstart_inc_from_field():
     rec_obj = model_field.to_python(value)
     assert rec_obj == limits
     # 2nd of August (dtstart) is expected but only for inc=True
-    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True,
-                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 2, 0, 0),
-                                                                   datetime(2015, 8, 3, 0, 0),
-                                                                   datetime(2015, 8, 10, 0, 0)]
-    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False,
-                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
-                                                                   datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 2, 0, 0), datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
 
     model_field = recurrence.fields.RecurrenceField(dtstart_inc=False)  # Test with dtstart_inc=False
     rec_obj = model_field.to_python(value)
     assert rec_obj == limits
     # 2nd of August (dtstart) is not expected regardless of inc
-    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True,
-                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
-                                                                   datetime(2015, 8, 10, 0, 0)]
-    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False,
-                                 dtstart=datetime(2015, 8, 2)) == [datetime(2015, 8, 3, 0, 0),
-                                                                   datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=True, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+    assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
+        datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
 
 
 def test_dtstart_inc_from_object():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -161,7 +161,7 @@ def test_check_allowable_frequencies():
     assert e.value.messages[0] == "Invalid frequency."
 
 
-def test_dtstart_inc_from_field():
+def test_include_dtstart_from_field():
     rule = Rule(
         recurrence.WEEKLY,
         byday=recurrence.MONDAY
@@ -173,7 +173,7 @@ def test_dtstart_inc_from_field():
 
     value = recurrence.serialize(limits)
 
-    model_field = recurrence.fields.RecurrenceField()  # Test with dtstart_inc=True (default)
+    model_field = recurrence.fields.RecurrenceField()  # Test with include_dtstart=True (default)
     rec_obj = model_field.to_python(value)
     assert rec_obj == limits
     # 2nd of August (dtstart) is expected but only for inc=True
@@ -182,7 +182,7 @@ def test_dtstart_inc_from_field():
     assert rec_obj.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
         datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
 
-    model_field = recurrence.fields.RecurrenceField(dtstart_inc=False)  # Test with dtstart_inc=False
+    model_field = recurrence.fields.RecurrenceField(include_dtstart=False)  # Test with include_dtstart=False
     rec_obj = model_field.to_python(value)
     assert rec_obj == limits
     # 2nd of August (dtstart) is not expected regardless of inc
@@ -192,13 +192,13 @@ def test_dtstart_inc_from_field():
         datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
 
 
-def test_dtstart_inc_from_object():
+def test_include_dtstart_from_object():
     rule = Rule(
         recurrence.WEEKLY,
         byday=recurrence.MONDAY
     )
 
-    limits = Recurrence(  # dtstart_inc=True (default)
+    limits = Recurrence(  # include_dtstart=True (default)
         rrules=[rule]
     )
 
@@ -207,8 +207,8 @@ def test_dtstart_inc_from_object():
     assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
         datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
 
-    limits = Recurrence(  # dtstart_inc=False (dtstart is expected to not be included)
-        dtstart_inc=False,
+    limits = Recurrence(  # include_dtstart=False (dtstart is expected to not be included)
+        include_dtstart=False,
         rrules=[rule]
     )
 


### PR DESCRIPTION
As stated by @jpulec in #90 `dtstart` is handled according to RFC 2445 so that it always counts as the first occurrence regardless of your pattern, like when used with `between()`. This causes confusion for some users (e.g. #36, #50, #71) because it is in conflict with how `dateutil.rrule` handles `dtstart`.

With this pull request I suggest a solution which consists of:

1. The addition of an optional parameter `include_dtstart` which can be either passed to a `RecurrenceField` or a `Recurrence` instance. With `include_dtstart=False` the default behavior does not occur for the field/object so that `dtstart` no longer finds its way into the occurrence list if it does not match your recurrence pattern. Because the default behavior doesn't change if `include_dtstart` is not specified backward compatibility is ensured.

2. A clear documentation of how `django-recurrence` handles `dtstart` and how it can be controlled with the feature described above. In that way further confusion should be prevented.

3. Some additional unit test cases.