### PR TITLE
Minor CSS tweaks to allow display with the Wagtail CMS admin.

### DIFF
--- a/recurrence/static/recurrence/css/recurrence.css
+++ b/recurrence/static/recurrence/css/recurrence.css
@@ -87,6 +87,11 @@ div.recurrence-widget .form {
 
 div.recurrence-widget .radio {
     margin-left: 0;
+    padding: 0px;
+}
+
+div.recurrence-widget .radio:before {
+    padding: 0px;
 }
 
 div.recurrence-widget .form ul {
@@ -175,6 +180,13 @@ div.recurrence-widget .yearly td {
 
 div.recurrence-widget .checkbox {
     margin-left: 0;
+    width: auto;
+    height: auto;
+}
+
+div.recurrence-widget .checkbox:before {
+    width: auto;
+    height: auto;
 }
 
 div.recurrence-widget .until-count {
@@ -291,13 +303,4 @@ table.recurrence-calendar .footer {
     overflow: hidden;
     border-bottom: 1px solid #ccc;
     border-right: 1px solid #ccc;
-}
-
-input[type=checkbox]:before {
-    width: auto;
-    height: auto;
-}
-
-input[type=radio]:before {
-    padding: 0px;
 }

--- a/recurrence/static/recurrence/css/recurrence.css
+++ b/recurrence/static/recurrence/css/recurrence.css
@@ -87,7 +87,6 @@ div.recurrence-widget .form {
 
 div.recurrence-widget .radio {
     margin-left: 0;
-    padding: 0px;
 }
 
 div.recurrence-widget .radio:before {
@@ -180,8 +179,6 @@ div.recurrence-widget .yearly td {
 
 div.recurrence-widget .checkbox {
     margin-left: 0;
-    width: auto;
-    height: auto;
 }
 
 div.recurrence-widget .checkbox:before {

--- a/recurrence/static/recurrence/css/recurrence.css
+++ b/recurrence/static/recurrence/css/recurrence.css
@@ -10,6 +10,7 @@ div.recurrence-widget div.panel {
 div.recurrence-widget select,
 div.recurrence-widget input {
     margin: 0 .5em;
+    width: auto;
 }
 
 div.recurrence-widget a.recurrence-label {
@@ -292,3 +293,11 @@ table.recurrence-calendar .footer {
     border-right: 1px solid #ccc;
 }
 
+input[type=checkbox]:before {
+    width: auto;
+    height: auto;
+}
+
+input[type=radio]:before {
+    padding: 0px;
+}


### PR DESCRIPTION
These tweaks allow proper display in the Wagtail admin by explicitly applying the styles within the Django admin to override defaults from the Wagtail admin. They shouldn't affect the look in the Django admin. Thanks for your efforts. If you'd like, I could add a section to the docs for integration with Wagtail.