### PR TITLE
Bug fix in deserialize

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -1002,9 +1002,8 @@ def deserialize(text, include_dtstart=True):
     for label, param_text in tokens:
         if not param_text:
             raise exceptions.DeserializationError('empty property: %r' % label)
-        if u'=' not in param_text:
-            params = param_text
-        else:
+
+        if label in (u'RRULE', u'EXRULE'):
             params = {}
             param_tokens = filter(lambda p: p, param_text.split(u';'))
             for item in param_tokens:
@@ -1017,7 +1016,6 @@ def deserialize(text, include_dtstart=True):
                 params[param_name] = list(map(
                     lambda i: i.strip(), param_value.split(u',')))
 
-        if label in (u'RRULE', u'EXRULE'):
             kwargs = {}
             for key, value in params.items():
                 if key == u'FREQ':
@@ -1075,13 +1073,13 @@ def deserialize(text, include_dtstart=True):
             else:
                 exrules.append(Rule(**kwargs))
         elif label == u'DTSTART':
-            dtstart = deserialize_dt(params)
+            dtstart = deserialize_dt(param_text)
         elif label == u'DTEND':
-            dtend = deserialize_dt(params)
+            dtend = deserialize_dt(param_text)
         elif label == u'RDATE':
-            rdates.append(deserialize_dt(params))
+            rdates.append(deserialize_dt(param_text))
         elif label == u'EXDATE':
-            exdates.append(deserialize_dt(params))
+            exdates.append(deserialize_dt(param_text))
 
     return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates, include_dtstart)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from recurrence import Recurrence, Rule
+from recurrence.exceptions import DeserializationError
+import pytest
 import recurrence
 
 
@@ -11,6 +13,51 @@ def test_rule_serialization():
     serialized = recurrence.serialize(rule)
     assert 'RRULE:FREQ=WEEKLY' == serialized
     assert recurrence.deserialize(serialized) == Recurrence(rrules=[rule])
+
+
+def test_no_equal_sign():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:A')
+
+
+def test_no_value():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:A=')
+
+
+def test_unknown_key():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:A=X')
+
+
+def test_bad_freq():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:FREQ=X')
+
+
+def test_bad_interval():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:INTERVAL=X')
+
+
+def test_bad_wkst():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:WKST=X')
+
+
+def test_bad_count():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:COUNT=X')
+
+
+def test_bad_byday():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:BYDAY=X')
+
+
+def test_bad_BYMONTH():
+    with pytest.raises(DeserializationError):
+        recurrence.deserialize('RRULE:BYMONTH=X')
 
 
 def test_complex_rule_serialization():


### PR DESCRIPTION
Calling deserialize('RRULE:A') would raise an AttributeError instead of DeserializationError, since the string was used incorrectly as a dict.
I added some tests to make sure DeserializationError is raised in all cases.