### PR TITLE
updating Recurrence class to be py3 compatible

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -16,6 +16,7 @@ import calendar
 import pytz
 import dateutil.rrule
 from django.utils import dateformat, timezone
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _, pgettext as _p
 from django.utils.six import string_types
 
@@ -243,6 +244,7 @@ class Rule(object):
             cache=cache, **kwargs)
 
 
+@python_2_unicode_compatible
 class Recurrence(object):
     """
     A combination of `Rule` and `datetime.datetime` instances.
@@ -319,7 +321,7 @@ class Recurrence(object):
     def __iter__(self):
         return self.occurrences()
 
-    def __unicode__(self):
+    def __str__(self):
         return serialize(self)
 
     def __hash__(self):


### PR DESCRIPTION
in python 3 the `__str__` method is called when converting a class to a
string (opposed to the `__unicode__` method in py2).  This change renames
the `__unicode__` method to `__str__`, so we can easily get the serialized
version of a Recurrence object and while doing so maintain py2
compatibility be wrapping the class with Django's
`python_2_unicode_compatible` decorator

for more info see https://docs.djangoproject.com/en/1.11/topics/python3/#str-and-unicode-methods