### PR TITLE
Add full support for django2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - TOX_ENV=py35-19
   - TOX_ENV=py35-110
   - TOX_ENV=py35-111
+  - TOX_ENV=py35-20
   - TOX_ENV=py35-master
   - TOX_ENV=docs
   - TOX_ENV=flake8

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -68,6 +68,7 @@ For Django 1.10 and above, you'll need:
 
     import django
     from django.conf.urls import url
+    from django.views.i18n import JavaScriptCatalog
 
     # Your normal URLs here...
 
@@ -79,7 +80,7 @@ For Django 1.10 and above, you'll need:
 
     # jsi18n can be anything you like here
     urlpatterns += [
-        url(r'^jsi18n/$', django.views.i18n.javascript_catalog, js_info_dict),
+        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), js_info_dict),
     )
 
 

--- a/recurrence/migrations/0001_initial.py
+++ b/recurrence/migrations/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
@@ -45,17 +46,17 @@ class Migration(migrations.Migration):
                 ('wkst', models.PositiveIntegerField(default=0, null=True, blank=True)),
                 ('count', models.PositiveIntegerField(null=True, blank=True)),
                 ('until', models.DateTimeField(null=True, blank=True)),
-                ('recurrence', models.ForeignKey(related_name='rules', to='recurrence.Recurrence')),
+                ('recurrence', models.ForeignKey(related_name='rules', on_delete=django.db.models.deletion.CASCADE, to='recurrence.Recurrence')),
             ],
         ),
         migrations.AddField(
             model_name='param',
             name='rule',
-            field=models.ForeignKey(related_name='params', to='recurrence.Rule'),
+            field=models.ForeignKey(related_name='params', on_delete=django.db.models.deletion.CASCADE, to='recurrence.Rule'),
         ),
         migrations.AddField(
             model_name='date',
             name='recurrence',
-            field=models.ForeignKey(related_name='dates', to='recurrence.Recurrence'),
+            field=models.ForeignKey(related_name='dates', on_delete=django.db.models.deletion.CASCADE, to='recurrence.Recurrence'),
         ),
     ]

--- a/recurrence/models.py
+++ b/recurrence/models.py
@@ -15,7 +15,7 @@ class Recurrence(models.Model):
 
 
 class Rule(models.Model):
-    recurrence = models.ForeignKey(Recurrence, related_name='rules')
+    recurrence = models.ForeignKey(Recurrence, related_name='rules', on_delete=models.CASCADE)
     mode = models.BooleanField(default=True, choices=choices.MODE_CHOICES)
     freq = models.PositiveIntegerField(choices=choices.FREQUENCY_CHOICES)
     interval = models.PositiveIntegerField(default=1)
@@ -31,13 +31,13 @@ class Rule(models.Model):
 
 
 class Date(models.Model):
-    recurrence = models.ForeignKey(Recurrence, related_name='dates')
+    recurrence = models.ForeignKey(Recurrence, related_name='dates', on_delete=models.CASCADE)
     mode = models.BooleanField(default=True, choices=choices.MODE_CHOICES)
     dt = models.DateTimeField()
 
 
 class Param(models.Model):
-    rule = models.ForeignKey(Rule, related_name='params')
+    rule = models.ForeignKey(Rule, related_name='params', on_delete=models.CASCADE)
     param = models.CharField(max_length=16)
     value = models.IntegerField()
     index = models.IntegerField(default=0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-{17,18,19,110,111,master},{py34}-{17,18,19,110,111,master},{py35}-{18,19,110,111,master},docs,flake8
+envlist = {py27}-{17,18,19,110,111,master},{py34}-{17,18,19,110,111,master},{py35}-{18,19,110,111,20,master},docs,flake8
 
 [testenv]
 basepython =
@@ -13,6 +13,7 @@ deps=
   19: django>=1.9,<1.10
   110: django>=1.10,<1.11
   111: django>=1.11,<1.12
+  20: django>=2.0,<2.1
   master: https://github.com/django/django/archive/master.tar.gz
   pytest-django==2.7.0
 commands=python setup.py test


### PR DESCRIPTION
* Set on_delete to CASCADE explicitly as required for django 2.0.  This mimics the default of prior django versions.
* Updated existing migration to explicitly set CASCADE.  As this was implicitly set before, this is only necessary for new users running the migration.
* Updated test suite to test django 2.0 + python 3.5.  Python 3.4 is being deprecated, so didn't add 3.4.  Happy to change if there's disagreement that we should also test 3.4.
* Updated documentation to use the as_view pattern for JavaScriptCatalog in urls.py.  