### PR TITLE
Change order that month and date are set

### DIFF
--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -239,8 +239,8 @@ recurrence.widget.Calendar.prototype = {
             day != this.date.getDate()) {
 
             this.date.setFullYear(year);
-            this.date.setMonth(month);
             this.date.setDate(day);
+            this.date.setMonth(month);
 
             recurrence.array.foreach(
                 this.elements.month_grid.cells, function(cell) {
@@ -406,8 +406,8 @@ recurrence.widget.DateSelector.prototype = {
                 if (!this.date)
                     this.date = recurrence.widget.date_today();
                 this.date.setFullYear(year);
-                this.date.setMonth(month);
                 this.date.setDate(day);
+                this.date.setMonth(month);
 
                 this.elements.date_field.value = datestring;
 

--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -238,10 +238,7 @@ recurrence.widget.Calendar.prototype = {
             month != this.date.getMonth() ||
             day != this.date.getDate()) {
 
-            this.date.setFullYear(year);
-            this.date.setMonth(month);
-            this.date.setDate(day);
-            this.date.setMonth(month);
+            this.date.setTime(new Date(year, month, day) / 1);
 
             recurrence.array.foreach(
                 this.elements.month_grid.cells, function(cell) {
@@ -406,11 +403,8 @@ recurrence.widget.DateSelector.prototype = {
 
                 if (!this.date)
                     this.date = recurrence.widget.date_today();
-		    
-                this.date.setFullYear(year);
-                this.date.setMonth(month);
-                this.date.setDate(day);
-                this.date.setMonth(month);
+
+                this.date.setTime(new Date(year, month, day) / 1);
 
                 this.elements.date_field.value = datestring;
 

--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -239,6 +239,7 @@ recurrence.widget.Calendar.prototype = {
             day != this.date.getDate()) {
 
             this.date.setFullYear(year);
+            this.date.setMonth(month);
             this.date.setDate(day);
             this.date.setMonth(month);
 
@@ -405,7 +406,9 @@ recurrence.widget.DateSelector.prototype = {
 
                 if (!this.date)
                     this.date = recurrence.widget.date_today();
+		    
                 this.date.setFullYear(year);
+                this.date.setMonth(month);
                 this.date.setDate(day);
                 this.date.setMonth(month);
 

--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -238,7 +238,7 @@ recurrence.widget.Calendar.prototype = {
             month != this.date.getMonth() ||
             day != this.date.getDate()) {
 
-            this.date.setTime(new Date(year, month, day) / 1);
+            this.date.setTime(new Date(year, month, day).getTime());
 
             recurrence.array.foreach(
                 this.elements.month_grid.cells, function(cell) {
@@ -404,7 +404,7 @@ recurrence.widget.DateSelector.prototype = {
                 if (!this.date)
                     this.date = recurrence.widget.date_today();
 
-                this.date.setTime(new Date(year, month, day) / 1);
+                this.date.setTime(new Date(year, month, day).getTime());
 
                 this.elements.date_field.value = datestring;
 

--- a/recurrence/static/recurrence/js/recurrence.js
+++ b/recurrence/static/recurrence/js/recurrence.js
@@ -679,19 +679,9 @@ recurrence.deserialize = function(text) {
         }
         var dt = new Date();
         if (text.indexOf('Z') > 0) {
-            dt.setUTCFullYear(year);
-            dt.setUTCMonth(month - 1);
-            dt.setUTCDate(day);
-            dt.setUTCHours(hour);
-            dt.setUTCMinutes(minute);
-            dt.setUTCSeconds(second);
+            dt.setTime(Date.UTC(year, month - 1, day, hour, minute, second) / 1);
         } else {
-            dt.setFullYear(year);
-            dt.setMonth(month - 1);
-            dt.setDate(day);
-            dt.setHours(hour);
-            dt.setMinutes(minute);
-            dt.setSeconds(second);
+            dt.setTime(new Date(year, month - 1, day, hour, minute, second) / 1);
         }
         return dt;
     };

--- a/recurrence/static/recurrence/js/recurrence.js
+++ b/recurrence/static/recurrence/js/recurrence.js
@@ -681,7 +681,7 @@ recurrence.deserialize = function(text) {
         if (text.indexOf('Z') > 0) {
             dt.setTime(Date.UTC(year, month - 1, day, hour, minute, second) / 1);
         } else {
-            dt.setTime(new Date(year, month - 1, day, hour, minute, second) / 1);
+            dt.setTime(new Date(year, month - 1, day, hour, minute, second).getTime());
         }
         return dt;
     };


### PR DESCRIPTION
Depending on the current day of the month and the day you're selecting in the calendar the widget will select a day in the wrong month. 

The easiest way to explain this is through an example. 

If it is currently January 30th and I choose the date February 15th in the calendar widget March 15th will show up as the chosen date.

Checking how the date is set showed that the year is updated, then the month, then the day. 

In the January 30th example the year is updated no problem. Then the month is updated to February, but since February doesn't have a 30th the JavaScript date library automatically accounts for this by setting the date to March 2nd. Lastly the day is finally set giving us the result March 15th