### PR TITLE
added typeerror exception and test for #89

### DIFF
--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -151,7 +151,8 @@ class RecurrenceField(forms.CharField):
             recurrence_obj = recurrence.deserialize(value)
         except exceptions.DeserializationError as error:
             raise forms.ValidationError(error.args[0])
-
+        except TypeError:
+            return None
         if not self.accept_dtstart:
             recurrence_obj.dtstart = None
         if not self.accept_dtend:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -216,3 +216,13 @@ def test_include_dtstart_from_object():
         datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
     assert limits.between(datetime(2015, 8, 2), datetime(2015, 8, 11), inc=False, dtstart=datetime(2015, 8, 2)) == [
         datetime(2015, 8, 3, 0, 0), datetime(2015, 8, 10, 0, 0)]
+
+
+def test_none_fieldvalue():
+
+    field = RecurrenceField()
+    value = None
+    return_obj = field.clean(value)
+
+    assert isinstance(return_obj, Recurrence) or return_obj is None
+

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -225,4 +225,3 @@ def test_none_fieldvalue():
     return_obj = field.clean(value)
 
     assert isinstance(return_obj, Recurrence) or return_obj is None
-


### PR DESCRIPTION
This is for #89  , where a `value` of None to the `clean` method results in an error when deserializing happens.  I haven't dug deep enough to know if this is the absolute best way to fix it, but at least it prevents the TypeError.  Added a test to test_fields.py as well.  Do with this as you please  :)