### PR TITLE
Django 2.1 compatibility fix for widget render method

### DIFF
--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -28,7 +28,7 @@ class RecurrenceWidget(forms.Textarea):
             defaults.update(attrs)
         super(RecurrenceWidget, self).__init__(defaults)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         elif isinstance(value, recurrence.Recurrence):


### PR DESCRIPTION
For Django 2.1 compatibility widget render method should always have renderer argument.

[Reference](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1)