### PR TITLE
 Django 2 compatibility fix for value_to_string 

### DIFF
--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -44,7 +44,7 @@ class RecurrenceField(fields.Field):
         setattr(cls, self.name, Creator(self))
 
     def value_to_string(self, obj):
-        return self.get_prep_value(self._get_val_from_obj(obj))
+        return self.get_prep_value(self.value_from_object(obj))
 
     def formfield(self, **kwargs):
         defaults = {

--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -28,7 +28,7 @@ class RecurrenceWidget(forms.Textarea):
             defaults.update(attrs)
         super(RecurrenceWidget, self).__init__(defaults)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         elif isinstance(value, recurrence.Recurrence):


### PR DESCRIPTION
As discussed [here](https://code.djangoproject.com/ticket/24716) the use of _get_val_from_obj inside the value_to_string method is deprecated and then removed in Django 2.

This generally not causes any problem, but trips up Django Rest Framework when using a serializer with this field.