### PR TITLE
Be more selective when including assets in the source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md
 include LICENSE
 include MANIFEST.in
 include pytest.ini
-recursive-include docs *
-recursive-include recurrence/static *
-recursive-include recurrence/locale *
-recursive-include tests *
+recursive-include docs Makefile make.bat *.rst *.py *.png
+recursive-include recurrence/static *.css *.png *.js
+recursive-include recurrence/locale *.mo *.po
+recursive-include tests *.py


### PR DESCRIPTION
Using a plain wildcard `*` also includes build-artifacts like `.pyc` files in
the source tarball. This is then flagged by systems like Debian's `lintian`
which checks for clean source tarballs.