### PR TITLE
Declare dependency on the admin's jQuery.js

### DIFF
--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -23,7 +23,10 @@ class RecurrenceWidget(forms.Textarea):
         super(RecurrenceWidget, self).__init__(defaults)
 
     def get_media(self):
+        extra = '' if settings.DEBUG else '.min'
         js = [
+            'vendor/jquery/jquery%s.js' % extra,
+            'admin/js/jquery.init.js',
             staticfiles_storage.url('recurrence/js/recurrence.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.init.js'),


### PR DESCRIPTION
Without this change, the admin loads recurrence-widget.init.js
before jquery.init.js. As a consequence, the `django.jQuery` variable
isn't created yet and the following error happens:

    Uncaught TypeError: django.jQuery is not a function at recurrence-widget.init.js:1

With this change, the admin loads JS scripts in the correct order.

Refs #142.