### PR TITLE
Clean up deprecated code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ cache:
     - $HOME/.pip-cache/
 
 env:
-  - TOX_ENV=py27-111
   - TOX_ENV=py36-111
-  - TOX_ENV=py36-20
   - TOX_ENV=py36-21
   - TOX_ENV=py36-22
   - TOX_ENV=py36-master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
 #
 # This file is execfile()d with the current directory set to its containing dir.

--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -16,9 +16,7 @@ import calendar
 import pytz
 import dateutil.rrule
 from django.utils import dateformat, timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _, pgettext as _p
-from django.utils.six import string_types
 
 from recurrence import exceptions
 from recurrence import settings
@@ -33,7 +31,7 @@ def localtz():
     return timezone.get_current_timezone()
 
 
-class Rule(object):
+class Rule:
     """
     A recurrence rule.
 
@@ -244,8 +242,7 @@ class Rule(object):
             cache=cache, **kwargs)
 
 
-@python_2_unicode_compatible
-class Recurrence(object):
+class Recurrence:
     """
     A combination of `Rule` and `datetime.datetime` instances.
 
@@ -589,7 +586,7 @@ class Recurrence(object):
         return rruleset
 
 
-class Weekday(object):
+class Weekday:
     """
     Representation of a weekday.
 
@@ -679,11 +676,11 @@ def to_weekday(token):
         return WEEKDAYS[token]
     elif not token:
         raise ValueError
-    elif isinstance(token, string_types) and token.isdigit():
+    elif isinstance(token, str) and token.isdigit():
         if int(token) > 6:
             raise ValueError
         return WEEKDAYS[int(token)]
-    elif isinstance(token, string_types):
+    elif isinstance(token, str):
         const = token[-2:].upper()
         if const not in Rule.weekdays:
             raise ValueError

--- a/recurrence/compat.py
+++ b/recurrence/compat.py
@@ -4,7 +4,7 @@ except ImportError:
     # This class was removed in Django 1.10, so I've pulled it into
     # django-recurrence.
 
-    class Creator(object):
+    class Creator:
         """
         A placeholder class that provides a way to set the attribute
         on the model.

--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -1,16 +1,7 @@
 from django.db.models import fields
-from django.utils.six import string_types
 import recurrence
 from recurrence import forms
 from recurrence.compat import Creator
-
-try:
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], [
-        "^recurrence\.fields\.RecurrenceField",
-    ])
-except ImportError:
-    pass
 
 
 # Do not use SubfieldBase meta class because is removed in Django 1.10
@@ -35,7 +26,7 @@ class RecurrenceField(fields.Field):
         return self.to_python(value)
 
     def get_prep_value(self, value):
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             value = recurrence.serialize(value)
         return value
 
@@ -52,4 +43,4 @@ class RecurrenceField(fields.Field):
             'widget': forms.RecurrenceWidget,
         }
         defaults.update(kwargs)
-        return super(RecurrenceField, self).formfield(**defaults)
+        return super().formfield(**defaults)

--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -1,13 +1,8 @@
-from django import forms
+from django import forms, urls
 from django.conf import settings
 from django.views import i18n
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.staticfiles.storage import staticfiles_storage
-
-try:
-    from django import urls
-except ImportError:
-    from django.core import urlresolvers as urls
 
 import recurrence
 from recurrence import exceptions
@@ -20,7 +15,7 @@ class RecurrenceWidget(forms.Textarea):
         defaults = {'class': 'recurrence-widget'}
         if attrs is not None:
             defaults.update(attrs)
-        super(RecurrenceWidget, self).__init__(defaults)
+        super().__init__(defaults)
 
     def get_media(self):
         extra = '' if settings.DEBUG else '.min'
@@ -122,7 +117,7 @@ class RecurrenceField(forms.CharField):
                 recurrence.HOURLY, recurrence.MINUTELY,
                 recurrence.SECONDLY,
             )
-        super(RecurrenceField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def clean(self, value):
         """

--- a/recurrence/migrations/0001_initial.py
+++ b/recurrence/migrations/0001_initial.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 import django.db.models.deletion
 

--- a/recurrence/settings.py
+++ b/recurrence/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Settings for django recurrence.
 

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,23 @@
 import os
 import sys
 
-try:
-    from setuptools import setup
-
-    has_setuptools = True
-except ImportError:
-    from distutils.core import setup
-
-    has_setuptools = False
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
 
 
-if has_setuptools:
-    from setuptools.command.test import test as TestCommand
+class PyTest(TestCommand):
+    def finalize_options(self):
+        self.test_args = []
+        self.test_suite = True
 
-    class PyTest(TestCommand):
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            self.test_args = []
-            self.test_suite = True
+        super().finalize_options()
 
-        def run_tests(self):
-            import pytest
+    def run_tests(self):
+        import pytest
 
-            errno = pytest.main(self.test_args)
-            sys.exit(errno)
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
-    setup_options = dict(
-        install_requires=("pytz", "python-dateutil"),
-        zip_safe=False,
-        include_package_data=True,
-        cmdclass={"test": PyTest},
-    )
-else:
-    setup_options = dict(requires=("pytz", "python_dateutil"))
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -56,14 +40,11 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ),
-    requires=("Django", "pytz", "python_dateutil"),
+    install_requires=("Django", "pytz", "python-dateutil"),
     packages=("recurrence", "recurrence.migrations"),
     package_dir={"recurrence": "recurrence"},
     package_data={
@@ -75,5 +56,7 @@ setup(
             os.path.join("locale", "*.mo"),
         ]
     },
-    **setup_options
+    zip_safe=False,
+    include_package_data=True,
+    cmdclass={"test": PyTest},
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test settings for django recurrence.
 

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test timezone aware recurrence date times."""
 
 from datetime import datetime

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,17 @@
 [tox]
-envlist = {py27}-{111},{py35}-{111,20,21,22},{py36}-{111,20,21,22,master},{py37}-{20,21,22,master},docs,flake8
+envlist = {py36,py37}-{111,21,22,master},docs,flake8
 
 [testenv]
 basepython =
-    py27: python2.7
-    py35: python3.5
     py36: python3.6
     py37: python3.7
 deps=
-  pytest
+  -r requirements_test.txt
   111: django>=1.11,<1.12
   20: django>=2.0,<2.1
   21: django>=2.1,<2.2
   22: django>=2.2,<2.3
   master: https://github.com/django/django/archive/master.tar.gz
-  pytest-django==3.5.1
 commands=python setup.py test
 
 [testenv:docs]


### PR DESCRIPTION
Remove old Python and Django compatibility code as discussed in django-recurrence issue #144 

Python 2.7 should be deprecated from web projects and Django 2.0 is EOL.