### PR TITLE
Fix incorrect month name for May in widget

### DIFF
--- a/recurrence/static/recurrence/js/recurrence.js
+++ b/recurrence/static/recurrence/js/recurrence.js
@@ -1075,19 +1075,19 @@ recurrence.display.last_of_month_short = {
 }
 recurrence.display.months = [
     gettext('January'), gettext('February'), gettext('March'),
-    gettext('April'), pgettext('month name', 'May'), gettext('June'),
+    gettext('April'), gettext('May'), gettext('June'),
     gettext('July'), gettext('August'), gettext('September'),
     gettext('October'), gettext('November'), gettext('December')
 ];
 recurrence.display.months_short = [
     gettext('Jan'), gettext('Feb'), gettext('Mar'),
-    gettext('Apr'), pgettext('month name', 'May'), gettext('Jun'),
+    gettext('Apr'), gettext('May'), gettext('Jun'),
     gettext('Jul'), gettext('Aug'), gettext('Sep'),
     gettext('Oct'), gettext('Nov'), gettext('Dec')
 ];
 recurrence.display.months_ap = [
     gettext('Jan.'), gettext('Feb.'), gettext('March'),
-    gettext('April'), pgettext('month name', 'May'), gettext('June'),
+    gettext('April'), gettext('May'), gettext('June'),
     gettext('July'), gettext('Aug.'), gettext('Sept.'),
     gettext('Oct.'), gettext('Nov.'), gettext('Dec.')
 ];


### PR DESCRIPTION
The month name for May in the widget was showing as "month name". This patch fixes that.