### PR TITLE
Fix: 404 in browsers console when using recurrence in django admin

### DIFF
--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -20,7 +20,7 @@ class RecurrenceWidget(forms.Textarea):
     def get_media(self):
         extra = '' if settings.DEBUG else '.min'
         js = [
-            'vendor/jquery/jquery%s.js' % extra,
+            'admin/js/vendor/jquery/jquery%s.js' % extra,
             'admin/js/jquery.init.js',
             staticfiles_storage.url('recurrence/js/recurrence.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.js'),


### PR DESCRIPTION
I encountered problems in the admin of a Wagtail/Django Website, when upgrading to the latest packages and narrowed down the error to django-recurrence 1.10.0

Django says: `[20/Jul/2019 13:16:25] "GET /static/vendor/jquery/jquery.js HTTP/1.1" 404 1691`
Chrome says: `GET http://0.0.0.0:8001/static/vendor/jquery/jquery.js net::ERR_ABORTED 404 (Not Found)`
Firefox says: `The script from “http://0.0.0.0:8001/static/vendor/jquery/jquery.js” was loaded even though its MIME type (“text/html”) is not a valid JavaScript MIME type.`

For testing purposes I set up a fresh Django 2.2.
Django puts its admin's jQuery per default to `static/admin/js/vendor/jquery/jquery.(min.)js`.

After my changes `make testall` results are still positive.
Thank you very much for this project!

Gabriel