### PR TITLE
Weekday should be int, not an object

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -1048,7 +1048,7 @@ def deserialize(text, include_dtstart=True):
                             'bad interval value: %r' % value[0])
                 elif key == u'WKST':
                     try:
-                        kwargs[str(key.lower())] = to_weekday(value[0])
+                        kwargs[str(key.lower())] = to_weekday(value[0]).number
                     except ValueError:
                         raise exceptions.DeserializationError(
                             'bad weekday value: %r' % value[0])


### PR DESCRIPTION
When you deserialize recurrence from string:
```
r = deserialize('DTSTART:20201015T000000\nRRULE:FREQ=WEEKLY;COUNT=30;INTERVAL=1;WKST=MO')
```

And then try to create a recurrence object:

```
Recurrence.objects.create_from_recurrence_object(r)
```

You'll get an error:
![Screenshot from 2020-10-15 12-40-23](https://user-images.githubusercontent.com/9641784/96107265-e5764d80-0ee4-11eb-8d4d-f94c67730eb5.png)

Because `r.wkst` is a `Weekday` object, but it should be an integer.