### PR TITLE
Replace deprecated ugettext method

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -16,7 +16,7 @@ import calendar
 import pytz
 import dateutil.rrule
 from django.utils import dateformat, timezone
-from django.utils.translation import ugettext as _, pgettext as _p
+from django.utils.translation import gettext as _, pgettext as _p
 
 from recurrence import exceptions
 from recurrence import settings

--- a/recurrence/choices.py
+++ b/recurrence/choices.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import recurrence
 

--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -1,7 +1,7 @@
 from django import forms, urls
 from django.conf import settings
 from django.views import i18n
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 import recurrence


### PR DESCRIPTION
We're replacing the deprecated `ugettext` and `ugettext_lazy` methods with the equivalent `gettext` and `gettext_lazy` methods (see https://github.com/django/django/blob/56f2cccc01f91918a227a2611331e4ea7e183286/django/utils/translation/__init__.py#L97 and https://github.com/django/django/blob/56f2cccc01f91918a227a2611331e4ea7e183286/django/utils/translation/__init__.py#L139).

Resolves https://github.com/django-recurrence/django-recurrence/issues/179.