### PR TITLE
Fix Django translation deprecation

### DIFF
--- a/recurrence/choices.py
+++ b/recurrence/choices.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import recurrence
 

--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -1,7 +1,7 @@
 from django import forms, urls
 from django.conf import settings
 from django.views import i18n
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 import recurrence


### PR DESCRIPTION
During usage of `from django-utils.translation import ugettext_lazy as _`

```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

This is aliased in django 2.0 and later, so it's safe to change.