### PR TITLE
Fix missing autopk field specification

### DIFF
--- a/recurrence/apps.py
+++ b/recurrence/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RecurrenceConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "recurrence"


### PR DESCRIPTION
Relates to https://github.com/jazzband/django-recurrence/issues/301

With the release of Django 6.0, Django 6.0 changed the DEFAULT_AUTO_FIELD setting default value to BigAutoField. Without this additional app config in this PR, the Django migrations checker complains that a migration is missing and generates a new one.

We've deployed this version into our nonprod environments as a test and the migration check error is gone.